### PR TITLE
-1e+10 のような number を受け付けない問題を修正

### DIFF
--- a/jsonpullparser-core/src/main/java/net/vvakame/util/jsonpullparser/JsonPullParser.java
+++ b/jsonpullparser-core/src/main/java/net/vvakame/util/jsonpullparser/JsonPullParser.java
@@ -808,8 +808,30 @@ public class JsonPullParser {
 
 	StringBuilder stb = new StringBuilder();
 
+	private void expectSignOrDigitAfterE() throws IOException, JsonFormatException{
+		char c = (char) br.read();
+		switch (c) {
+			case '+':
+			case '-':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+                br.mark(1);
+                stb.append(c);
+				break;
+			default:
+				throw new JsonFormatException("unexpected char. expected '+' or '-' or digit", this);
+		}
+	}
 
-	private void fetchNextNumeric() throws IOException {
+	private void fetchNextNumeric() throws IOException, JsonFormatException {
 		stb.setLength(0);
 		br.reset();
 		char c;
@@ -839,6 +861,9 @@ public class JsonPullParser {
 			}
 			br.mark(1);
 			stb.append(c);
+			if (c == 'e' || c == 'E') {
+			   expectSignOrDigitAfterE();
+			}
 		}
 		if (d) {
 			valueDouble = Double.parseDouble(stb.toString());

--- a/jsonpullparser-core/src/test/java/net/vvakame/util/jsonpullparser/JsonPullParserTest.java
+++ b/jsonpullparser-core/src/test/java/net/vvakame/util/jsonpullparser/JsonPullParserTest.java
@@ -335,6 +335,34 @@ public class JsonPullParserTest {
 	}
 
 	/**
+	 * Tests the handling of {@link State#VALUE_DOUBLE}.
+	 * @throws IOException
+	 * @throws JsonFormatException
+	 * @author Shinpeim
+	 */
+	@Test
+	public void parseDoubleWhichContainsPlusAfterE() throws IOException, JsonFormatException {
+		State type;
+		String str;
+		double d;
+
+		JsonPullParser parser = JsonPullParser.newParser("{\"key\":-1e+6}");
+		type = parser.getEventType();
+		assertThat(type, is(State.START_HASH));
+		type = parser.getEventType();
+		assertThat(type, is(State.KEY));
+		str = parser.getValueString();
+		assertThat(str, is("key"));
+		type = parser.getEventType();
+		assertThat(type, is(State.VALUE_DOUBLE));
+		d = parser.getValueDouble();
+		assertThat(d, is(-1000000.0));
+		type = parser.getEventType();
+		assertThat(type, is(State.END_HASH));
+	}
+
+
+	/**
 	 * Tests the handling of {@link State#START_HASH} and {@link State#END_HASH}.
 	 * @throws IOException
 	 * @throws JsonFormatException


### PR DESCRIPTION
http://json.org/ にある通り、number は 'e'/'E' のあとに '+'/'-'/digit のいずれかを取ることができますが、fetchNextNumeric で '+' を受け付けていなかったので、 'e'/'E' のあとには + や - も受け入れるようにしました。

fetchNextNumeric の中のswitchに '+' を追加することも考えたのですが、その場合 '+1' のようなものも valid な number として通してしまうことになるのでこのような実装になっています。
